### PR TITLE
set robots tag value as placeholder instead of inserting code

### DIFF
--- a/_build/data/transport.plugin.events.php
+++ b/_build/data/transport.plugin.events.php
@@ -13,9 +13,9 @@ $events['OnBeforeDocFormSave']->fromArray(array(
     'priority' => 0,
     'propertyset' => 0,
 ),'',true,true);
-$events['OnHandleRequest']= $modx->newObject('modPluginEvent');
-$events['OnHandleRequest']->fromArray(array(
-    'event' => 'OnHandleRequest',
+$events['OnLoadWebDocument']= $modx->newObject('modPluginEvent');
+$events['OnLoadWebDocument']->fromArray(array(
+    'event' => 'OnLoadWebDocument',
     'priority' => 0,
     'propertyset' => 0,
 ),'',true,true);

--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -103,14 +103,13 @@ switch ($modx->event->name) {
 
         	$resource->setProperties($newProperties,'stercseo');
 		break;
-	case 'OnHandleRequest':
-		$resource = $modx->getObject('modResource', array('uri' => $_GET['q']));
-		if($resource){
-			$properties = $resource->getProperties('stercseo');
+	case 'OnLoadWebDocument':
+		if($modx->resource){
+			$properties = $modx->resource->getProperties('stercseo');
 			$metaContent = array('noopd', 'noydir');
 			if(!$properties['index']) $metaContent[] = 'noindex';
 			if(!$properties['follow']) $metaContent[] = 'nofollow';
-			$modx->regClientStartupHTMLBlock('<meta name="robots" content="'.implode(',', $metaContent).'" />');
+			$modx->setPlaceholder('seoTab.robotsTag',implode(',', $metaContent));
 		}
 
 		break;


### PR DESCRIPTION
Inserting code into the document is "not the MODX way"... Also `regClientStartupHTMLBlock` didn't work on `OnHandleRequest`.

Switched to event `OnLoadWebDocument` and inserting now a Placeholder `[[+seoTab.robotsTag]]` that includes the value and could be integrated into the template like

```
<meta name="robots" content="[[+seoTab.robotsTag]]">
```

...thats creative freedom for the developer :)

Note: do we need to add any script that changes the event during a update? Or is this done automatically by the changes in build script.

ToDo for freedom:
The default value (Line 109) should be editable through a system setting.
