### PR TITLE
fixes #19

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -107,7 +107,7 @@ switch ($modx->event->name) {
 		$resource = $modx->getObject('modResource', array('uri' => $_GET['q']));
 		if($resource){
 			$properties = $resource->getProperties('stercseo');
-			$metaContent = array('noopd', 'noydir');
+			$metaContent = array('noodp', 'noydir');
 			if($properties){
 				if(!$properties['index']) $metaContent[] = 'noindex';
 				if(!$properties['follow']) $metaContent[] = 'nofollow';


### PR DESCRIPTION
there was a typo in the default robots tag content. It's noodp instead of noopd.
