### PR TITLE
get correct request uri

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -104,7 +104,9 @@ switch ($modx->event->name) {
         	$resource->setProperties($newProperties,'stercseo');
 		break;
 	case 'OnHandleRequest':
-		$resource = $modx->getObject('modResource', array('uri' => $_GET['q']));
+		if ($modx->context->get('key') == 'mgr') return;
+		$uri = $_REQUEST[$modx->getOption('request_param_alias', null, 'q')];
+		$resource = $modx->getObject('modResource', array('uri' => $uri));
 		if($resource){
 			$properties = $resource->getProperties('stercseo');
 			$metaContent = array('noopd', 'noydir');


### PR DESCRIPTION
The `q` could be changed in the settings so get the value from the settings. Also you should use $_REQUEST instead of $_GET, since $_REQUEST contains the correct URI without the base_url of the context (as its saved in the uri field of a resource).

This fixes issue #18.
