### PR TITLE
Fix OnPageNotFound

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -118,13 +118,13 @@ switch ($modx->event->name) {
 		break;
 
 	case 'OnPageNotFound':
-		$convertedUrl = str_replace('/', '_/', ltrim($_SERVER['REQUEST_URI'], '/'));
+		$url = $_REQUEST[$modx->getOption('request_param_alias', null, 'q')];
 		$alreadyExists = $modx->getObject('modResource', array(
-			'properties:LIKE' => '%"'.$convertedUrl.'"%'
+			'properties:LIKE' => '%"'.$url.'"%'
 		));
 		if($alreadyExists){
-			$url = $modx->makeUrl($alreadyExists->get('id'));
-			$modx->sendRedirect($url, 0, 'REDIRECT_HEADER', 'HTTP/1.1 301 Moved Permanently');
+			$id = $modx->makeUrl($alreadyExists->get('id'));
+			$modx->sendRedirect($id, 0, 'REDIRECT_HEADER', 'HTTP/1.1 301 Moved Permanently');
 		}
 		break;
 	case 'OnResourceBeforeSort':


### PR DESCRIPTION
I'm not sure why you used REQUEST_URI here. At least in multi-context setups this doesn't work since it would contain the base_url of the context and so no matching resource would be found (since the uri of the resource does not contain the base_url).

So like in #22 I'm using $_REQUEST which works fine.
