### PR TITLE
Test against explicit removal from sitemap

### DIFF
--- a/core/components/stercseo/model/stercseo/stercseo.class.php
+++ b/core/components/stercseo/model/stercseo/stercseo.class.php
@@ -145,8 +145,7 @@ class StercSEO {
     public function sitemap($contextKey = 'web', $rowTpl, $outerTpl){
         $resources = $this->modx->getCollection('modResource',
             array(
-                array('context_key' => $contextKey, 'published' => 1, 'deleted' => 0),
-                array('properties:LIKE' => '%"sitemap":"1"%', 'OR:properties:LIKE' => '%"sitemap":null%', 'OR:properties:IS' => NULL)
+                array('context_key' => $contextKey, 'published' => 1, 'deleted' => 0, 'properties:NOT LIKE'=> '%"sitemap":"0"%')
             )
         );
         foreach($resources AS $resource){


### PR DESCRIPTION
Had it search for only instances where sitemap was set to 0, the other way was failing as explained in Issue #29
