### PR TITLE
Fetch site_url from context setting if exists.

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -301,10 +301,13 @@ switch ($modx->event->name) {
                 'deleted' => '0',
                 'context_key' => $resource->get('context_key')
             ));
-
+            
+            $ctx = $modx->getContext($resource->get('context_key'));
+            $site_url = $ctx->getOption('site_url','',$modx->getOption('site_url'));
+            
             $childResources = $modx->getIterator('modResource', $cond);
             foreach ($childResources as $childResource) {
-                $url = urlencode($modx->getOption('site_url').$childResource->get('uri'));
+                $url = urlencode($site_url.$childResource->get('uri'));
                 if (!$modx->getCount('seoUrl', array('url' => $url))) {
                     $data = array(
                         'url' => $url,


### PR DESCRIPTION
On sort modx->(site_url) doesn't fetch the context setting but uses allround system_setting or generated site_url.
Also remove getOption call from loop.