### PR TITLE
Fixing issue-149 Alias not found errors

### DIFF
--- a/core/components/stercseo/processors/mgr/redirect/getlist.class.php
+++ b/core/components/stercseo/processors/mgr/redirect/getlist.class.php
@@ -44,7 +44,10 @@ class StercSeoGetListProcessor extends modObjectGetListProcessor
             $resourceObject = $this->modx->getObject('modResource', $resourceId);
             if ($resourceObject) {
                 $pagetitle = $resourceObject->get('pagetitle');
-                $object->set('target', $pagetitle.' ('.$resourceId.')<br><i><small>'.$this->modx->makeUrl($resourceId, '', '', 'full').'</small></i>');
+                $object->set(
+                    'target',
+                    $pagetitle.' ('.$resourceId.')<br><i><small>'.$this->modx->makeUrl($resourceId, $resourceObject->get('context_key'), '', 'full').'</small></i>'
+                );
             }
         }
         $object->set('url', urldecode($object->get('url')));


### PR DESCRIPTION
This issue fixes the following warning:
```
Error is: [2018-04-24 08:09:58] (WARN @ /core/model/modx/modcontext.class.php : 244) `20` was requested but no alias was located.
```

Related issue:
https://github.com/Sterc/SEOTab/issues/149