### PR TITLE
Fixing-153 PHP Undefined index: HTTPS

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -233,7 +233,8 @@ switch ($modx->event->name) {
 
     case 'OnPageNotFound':
         $options      = array();
-	$url          = (isset($_SERVER['HTTPS']) ? 'https' : 'http') . '://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+        $protocol     = $modx->getOption('server_protocol', null, 'https');
+        $url          = $protocol . '://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
         $convertedUrl = urlencode($url);
 
         $w = array(

--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -233,7 +233,7 @@ switch ($modx->event->name) {
 
     case 'OnPageNotFound':
         $options      = array();
-        $url          = ($_SERVER['HTTPS'] ? 'https' : 'http').'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+	$url          = (isset($_SERVER['HTTPS']) ? 'https' : 'http') . '://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
         $convertedUrl = urlencode($url);
 
         $w = array(


### PR DESCRIPTION
Fixes the undefined index error by checking if HTTPS property is set.

Related issue:
https://github.com/Sterc/SEOTab/issues/153 