### PR TITLE
Make all resource fields available as placeholders in sitemap rowtpl

### DIFF
--- a/core/components/stercseo/model/stercseo/stercseo.class.php
+++ b/core/components/stercseo/model/stercseo/stercseo.class.php
@@ -225,11 +225,14 @@ class StercSEO
 
             $output .= $this->getChunk(
                 $rowTpl,
-                array(
-                    'url'        => $this->modx->makeUrl($resource->get('id'), '', '', 'full'),
-                    'lastmod'    => date('c', $lastmod),
-                    'changefreq' => (!empty($properties['changefreq']) ? $properties['changefreq'] : $this->defaults['changefreq']),
-                    'priority'   => (!empty($properties['priority']) ? $properties['priority'] : $this->defaults['priority']),
+                array_merge(
+                    $resource->toArray(),
+                    array(
+                        'url'        => $this->modx->makeUrl($resource->get('id'), '', '', 'full'),
+                        'lastmod'    => date('c', $lastmod),
+                        'changefreq' => (!empty($properties['changefreq']) ? $properties['changefreq'] : $this->defaults['changefreq']),
+                        'priority'   => (!empty($properties['priority']) ? $properties['priority'] : $this->defaults['priority']),
+                    )
                 )
             );
         }


### PR DESCRIPTION
Makes all resource fields available as placeholders in sitemap rowtpl

Related issue:
https://github.com/Sterc/SEOTab/issues/150