### PR TITLE
Fixing not empty check 143

### DIFF
--- a/core/components/stercseo/model/stercseo/stercseo.class.php
+++ b/core/components/stercseo/model/stercseo/stercseo.class.php
@@ -583,7 +583,7 @@ class StercSEO
         if (!$user) {
             $user = $this->modx->getUser();
         }
-        $exclUsergroups = explode(',', $this->modx->getOption('stercseo.hide_from_usergroups'));
+        $exclUsergroups = array_filter(explode(',', $this->modx->getOption('stercseo.hide_from_usergroups')));
         if (!empty($exclUsergroups)) {
             foreach ($exclUsergroups as $exclUserGroup) {
                 if ($user->isMember($exclUserGroup)) {


### PR DESCRIPTION
Fixing not empty check 143, without array_filter `$exclUsergroups` contains a single empty array entry.

**Related issue**
https://github.com/Sterc/SEOTab/issues/143