### PR TITLE
Fixing isssue 141

### DIFF
--- a/assets/components/stercseo/js/mgr/widgets/redirects.grid.js
+++ b/assets/components/stercseo/js/mgr/widgets/redirects.grid.js
@@ -217,6 +217,7 @@ StercSEO.window.Redirect = function(config) {
             ,displayField: 'pagetitle'
             ,baseParams: {
                 action: 'mgr/resource/getlist'
+                ,id: id
                 ,limit: 20
                 ,sort: 'pagetitle'
                 ,dir: 'asc'

--- a/core/components/stercseo/processors/mgr/resource/getlist.class.php
+++ b/core/components/stercseo/processors/mgr/resource/getlist.class.php
@@ -28,6 +28,17 @@ class StercSeoResourceGetListProcessor extends modObjectGetListProcessor
         return $c;
     }
 
+    public function getData()
+    {
+        $data = parent::getData();
+
+        if ($this->getProperty('start') === 0 && (int) $this->getProperty('id') > 0) {
+            $data['results'][] = $this->modx->getObject('modResource', $this->getProperty('id'));
+        }
+
+        return $data;
+    }
+
     public function prepareRow(xPDOObject $object)
     {
         $context_key = $object->get('context_key');


### PR DESCRIPTION
Fixes this issue: "When updating a redirect with a new Url/Resource that is not being retrieved within the first page of the combobox the value is not being displayed properly."

**Related issue:**
https://github.com/Sterc/SEOTab/issues/141