### PR TITLE
Making redirect URLs independent of server protocol

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -240,21 +240,27 @@ switch ($modx->event->name) {
         break;
 
     case 'OnPageNotFound':
-        $options      = array();
-        $protocol     = $modx->getOption('server_protocol', null, 'https');
-        $url          = $protocol . '://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
-        $convertedUrl = urlencode($url);
+        $options = array();
+        $query   = $modx->newQuery('seoUrl');
 
-        $w = array(
-            'url' => $convertedUrl
-        );
+        $query->where(array(
+            array(
+                'url' => urlencode('http://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'])
+            ),
+            array(
+                'url' => urlencode('https://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'])
+            )
+        ),xPDOQuery::SQL_OR);
 
-        if ($modx->getOption('stercseo.context-aware-alias', null, '0')) {
-            $w['context_key'] = $modx->context->key;
-        }
+         if ($modx->getOption('stercseo.context-aware-alias', null, '0')) {
+             $query->where(
+                 array(
+                     'context_key' => $modx->context->key
+                 )
+             );
+         }
 
-        $alreadyExists = $modx->getObject('seoUrl', $w);
-
+        $alreadyExists = $modx->getObject('seoUrl', $query);
         if (isset($alreadyExists) && ($modx->context->key !== $alreadyExists->get('context_key'))) {
             $q = $modx->newQuery('modContextSetting');
             $q->where(array(

--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -242,13 +242,14 @@ switch ($modx->event->name) {
     case 'OnPageNotFound':
         $options = array();
         $query   = $modx->newQuery('seoUrl');
+        $url     = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
         $query->where(array(
             array(
-                'url' => urlencode('http://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'])
+                'url' => urlencode('http://' . $url)
             ),
             array(
-                'url' => urlencode('https://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'])
+                'url' => urlencode('https://' . $url)
             )
         ),xPDOQuery::SQL_OR);
 


### PR DESCRIPTION
Changed onPageNotFound event so that it searches for an existing redirect URL with either the http or https protocol and it will redirect if a redirect URL has been found.

Situation before was that it would only redirect if a redirect URL was found with the same protocol as defined in the system setting.

**Related issues**
- https://github.com/Sterc/SEOTab/issues/91
- https://github.com/Sterc/SEOTab/issues/147