### PR TITLE
Added type is index check to show hidden XML sitemaps in the XML index sitemap

### DIFF
--- a/core/components/stercseo/model/stercseo/stercseo.class.php
+++ b/core/components/stercseo/model/stercseo/stercseo.class.php
@@ -319,9 +319,14 @@ class StercSEO
         $c->where(
             array(
                 array('context_key:IN' => $contextKey, 'published' => 1, 'deleted' => 0),
-                array('properties:LIKE' => '%"sitemap":"1"%', 'OR:properties:LIKE' => '%"sitemap":null%', 'OR:properties:IS' => null)
             )
         );
+
+        if ($options['type'] !== 'index') {
+            $c->where(
+                array('properties:LIKE' => '%"sitemap":"1"%', 'OR:properties:LIKE' => '%"sitemap":null%', 'OR:properties:IS' => null)
+            );
+        }
 
         if (!$allowSymlinks) {
             $c->where(array('class_key:!=' => 'modSymLink'));


### PR DESCRIPTION
Added check if type is index, then the sitemap properties are ignored so XML sitemaps can be shown in the index XML sitemap and be hidden from normal resources XML sitemaps.

**Related isssue:**
https://github.com/Sterc/SEOTab/issues/131