### PR TITLE
Adding system setting for XML sitemap for hiding children based on parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ An example of a sitemap-call with all properties set to a default-value would be
 [[!StercSeoSiteMap? &contexts=`web` &allowSymlinks=`0` &outerTpl=`sitemap/outertpl` &rowTpl=`sitemap/rowtpl`]]
 ```
 
+**XML Sitemap related system settings**
+
+| Key                                           | Description                                                                                                                                                   |
+|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| stercseo.xmlsitemap.babel.add_alternate_links | Add alternate links to XML Sitemap based on Babel Translations                                                                                                |
+| stercseo.xmlsitemap.dependent_ultimateparent  | Resources depend on properties of parent/ultimate parent. This enables you to hide resources if their parent/ultimate parent resource is deleted/unpublished. |
+
 ### Creating an index sitemap and template specific sitemaps
 In order to create an index sitemap please follow the steps below:
 1. Create a Google Sitemap page as you would normally do and add the parameter &type=`index`, for example:

--- a/_build/config.json
+++ b/_build/config.json
@@ -78,6 +78,11 @@
             "value": "1",
             "area": "XML Sitemap"
         }, {
+            "key": "xmlsitemap.dependent_ultimateparent",
+            "type": "combo-boolean",
+            "value": "0",
+            "area": "XML Sitemap"
+        }, {
             "key": "user_name",
             "type": "textfield",
             "area": "general",

--- a/core/components/stercseo/lexicon/de/default.inc.php
+++ b/core/components/stercseo/lexicon/de/default.inc.php
@@ -90,6 +90,8 @@ $_lang['setting_stercseo.hide_from_usergroups'] = 'SEO Tab für diese Benutzergr
 $_lang['setting_stercseo.hide_from_usergroups_desc'] = 'Kommaseparierte Liste von Benutzergruppen, denen nicht erlaubt ist, auf SEO Tab zuzugreifen';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links'] = 'Add alternate links to XML Sitemap';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links_desc'] = 'Adds alternate links to XML Sitemap URLs based on Babel translations.';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent'] = 'Resources depend on properties of parent/ultimate parent';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent_desc'] = 'If turned on, resources will be hidden from the XML sitemap if their parent or ultimate parent resource is deleted or unpublished.';
 
 // CMP
 $_lang['stercseo.redirects.description'] = 'Hier können Sie Ihre 301 Weiterleitungen anschauen und bearbeiten. Weiterleitungen können ebenso auf den Ressourcen Seiten beim Anlegen und Bearbeiten hinzugefügt werden.';

--- a/core/components/stercseo/lexicon/en/default.inc.php
+++ b/core/components/stercseo/lexicon/en/default.inc.php
@@ -88,6 +88,8 @@ $_lang['setting_stercseo.hide_from_usergroups'] = 'Hide SEO Tab from these userg
 $_lang['setting_stercseo.hide_from_usergroups_desc'] = 'Comma separated list of usergroups who are not allowed to access SEO Tab';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links'] = 'Add alternate links to XML Sitemap';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links_desc'] = 'Adds alternate links to XML Sitemap URLs based on Babel translations.';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent'] = 'Resources depend on properties of parent/ultimate parent';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent_desc'] = 'If turned on, resources will be hidden from the XML sitemap if their parent or ultimate parent resource is deleted or unpublished.';
 
 // CMP
 $_lang['stercseo.redirects.description'] = 'Manage your SEO Tab 301 redirects. 

--- a/core/components/stercseo/lexicon/fr/default.inc.php
+++ b/core/components/stercseo/lexicon/fr/default.inc.php
@@ -89,6 +89,8 @@ $_lang['setting_stercseo.hide_from_usergroups'] = 'Hide SEO Tab from these userg
 $_lang['setting_stercseo.hide_from_usergroups_desc'] = 'Comma separated list of usergroups who are not allowed to access SEO Tab';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links'] = 'Add alternate links to XML Sitemap';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links_desc'] = 'Adds alternate links to XML Sitemap URLs based on Babel translations.';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent'] = 'Resources depend on properties of parent/ultimate parent';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent_desc'] = 'If turned on, resources will be hidden from the XML sitemap if their parent or ultimate parent resource is deleted or unpublished.';
 
 // CMP
 $_lang['stercseo.redirects.description'] = 'Gérez ici vos redirections 301. Les redirections peuvent également être ajoutées depuis les pages de création et d\'édition de ressources.';

--- a/core/components/stercseo/lexicon/nl/default.inc.php
+++ b/core/components/stercseo/lexicon/nl/default.inc.php
@@ -89,6 +89,8 @@ $_lang['setting_stercseo.hide_from_usergroups'] = 'Verberg SEO Tab voor deze geb
 $_lang['setting_stercseo.hide_from_usergroups_desc'] = 'Komma gescheiden lijst met gebruikersgroepen die geen toegang hebben tot SEO Tab';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links'] = 'Voeg alternatieve links toe aan de XML Sitemap';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links_desc'] = 'Voeg alternatieve links toe aan de XML Sitemap URLs op basis van Babel vertalingen.';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent'] = 'Toon pagina\'s afhankelijk van de parent/ultieme parent';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent_desc'] = 'Indien aangezet worden pagina\'s uitgesloten van de XML sitemap indien de parent/ultimate parent pagina is verwijderd of gedepubliceerd.';
 
 // CMP
 $_lang['stercseo.redirects.description'] = 'Hier kun je je 301 redirects bekijken en beheren. Redirects kunnen ook worden toegevoegd vanuit de bron maak- en updatepagina\'s.';

--- a/core/components/stercseo/lexicon/ru/default.inc.php
+++ b/core/components/stercseo/lexicon/ru/default.inc.php
@@ -89,6 +89,8 @@ $_lang['setting_stercseo.hide_from_usergroups'] = 'Скрывать вкладк
 $_lang['setting_stercseo.hide_from_usergroups_desc'] = 'Список разделенный запятыми групп пользователей, которым не разрешен доступ к вкладке «SEO». Пример: "Administrator,Manager"';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links'] = 'Add alternate links to XML Sitemap';
 $_lang['setting_stercseo.xmlsitemap.babel.add_alternate_links_desc'] = 'Adds alternate links to XML Sitemap URLs based on Babel translations.';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent'] = 'Resources depend on properties of parent/ultimate parent';
+$_lang['setting_stercseo.xmlsitemap.dependent_ultimateparent_desc'] = 'If turned on, resources will be hidden from the XML sitemap if their parent or ultimate parent resource is deleted or unpublished.';
 
 // CMP
 $_lang['stercseo.redirects.description'] = 'Здесь вы можете просматривать и управлять своими 301 редиректами. Перенаправления также могут быть добавлены со страниц ресурсов.';

--- a/core/components/stercseo/model/stercseo/stercseo.class.php
+++ b/core/components/stercseo/model/stercseo/stercseo.class.php
@@ -291,6 +291,13 @@ class StercSEO
             return $this->sitemapImages($contextKey, $resources, $options);
         }
 
+        /* If resources should be displayed based upon parent/ultimate parent properties. */
+        $sitemapDependsOnUltimateParent = (bool) $this->getOption('stercseo.xmlsitemap.dependent_ultimateparent', null, false);
+        if ($sitemapDependsOnUltimateParent) {
+            $resources = $this->transformArray($resources);
+            $resources = $this->filterResourcesByParentProperties($resources);
+        }
+
         $output = '';
         foreach ($resources as $resource) {
             $properties = $resource->getProperties('stercseo');
@@ -310,7 +317,40 @@ class StercSEO
                 )
             );
         }
+
         return $this->getChunk($outerTpl, array('wrapper' => $output));
+    }
+
+    /**
+     * Transform array so it is indexed by resource id.
+     *
+     * @param $resources
+     * @return array
+     */
+    public function transformArray($resources)
+    {
+        $array = [];
+
+        if  ($resources) {
+            foreach ($resources as $resource) {
+                $array[$resource->get('id')] = $resource;
+            }
+        }
+
+        return $array;
+    }
+
+    public function filterResourcesByParentProperties($resources)
+    {
+        foreach ($resources as $resourceId => $resource) {
+            if ($resource->get('parent') > 0) {
+                if (!array_key_exists($resource->get('parent'), $resources)) {
+                    unset($resources[$resource->get('id')]);
+                }
+            }
+        }
+
+        return $resources;
     }
 
     /**


### PR DESCRIPTION
Adding system setting which will automatically hide childresources from XML sitemap if parent page is unpublished.

**Related issue:**
https://github.com/Sterc/SEOTab/issues/37