### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/_packages/stercseo-2.2.0-pl/manifest.php
+++ b/_packages/stercseo-2.2.0-pl/manifest.php
@@ -602,7 +602,7 @@ SEOTab 1.0.0-pl
       'vehicle_class' => 'xPDOObjectVehicle',
       'class' => 'modCategory',
       'guid' => 'de080e3e39a3a5e9608baa05272fa7e9',
-      'native_key' => NULL,
+      'native_key' => null,
       'filename' => 'modCategory/f2f25e21af48c449b26ab197bc6a6352.vehicle',
       'namespace' => 'stercseo',
     ),

--- a/_packages/stercseo-2.2.0-pl/modCategory/f2f25e21af48c449b26ab197bc6a6352/1/stercseo/model/stercseo/mysql/seourl.map.inc.php
+++ b/_packages/stercseo-2.2.0-pl/modCategory/f2f25e21af48c449b26ab197bc6a6352/1/stercseo/model/stercseo/mysql/seourl.map.inc.php
@@ -4,7 +4,7 @@
  */
 $xpdo_meta_map['seoUrl']= array (
   'package' => 'stercseo',
-  'version' => NULL,
+  'version' => null,
   'table' => 'seo_urls',
   'extends' => 'xPDOSimpleObject',
   'fields' => 

--- a/core/components/stercseo/model/stercseo/mysql/seourl.map.inc.php
+++ b/core/components/stercseo/model/stercseo/mysql/seourl.map.inc.php
@@ -4,7 +4,7 @@
  */
 $xpdo_meta_map['seoUrl']= array (
   'package' => 'stercseo',
-  'version' => NULL,
+  'version' => null,
   'table' => 'seo_urls',
   'extends' => 'xPDOSimpleObject',
   'fields' => 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!