### PR TITLE
fix for deprecated warning filling up error log about $modx->sendRedirect

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -295,7 +295,7 @@ switch ($modx->event->name) {
         if ($alreadyExists) {
             $url = $modx->makeUrl($alreadyExists->get('resource'), $alreadyExists->get('context_key'), '', 'full', $options);
 
-            $modx->sendRedirect($url, 0, 'REDIRECT_HEADER', 'HTTP/1.1 301 Moved Permanently');
+            $modx->sendRedirect($url, ['responseCode' => 'HTTP/1.1 301 Moved Permanently']);
         }
         break;
 


### PR DESCRIPTION
The used sendRedirect call is deprecated since MODX 2.0.5 and so it fills the log with errors.

Changed the sendRedirect to the current form
https://docs.modx.com/revolution/2.x/developing-in-modx/other-development-resources/class-reference/modx/modx.sendredirect
