### PR TITLE
Allow special characters in redirect URLs

### DIFF
--- a/core/components/stercseo/elements/plugins/stercseo.plugin.php
+++ b/core/components/stercseo/elements/plugins/stercseo.plugin.php
@@ -71,7 +71,7 @@ switch ($modx->event->name) {
         } elseif ($resource) {
             $properties['searchable'] = $resource->get('searchable');
         }
-    
+
         $properties['urls'] = '';
         // Fetch urls from seoUrl collection
         if ($urls && is_object($urls)) {
@@ -210,11 +210,11 @@ switch ($modx->event->name) {
         if (!$stercseo->isAllowed($resource->context_key)) {
             return;
         }
-        
+
         /* Tmp overwrite the cache_alias_map setting to prevent that a redirect is removed again. */
         $cacheAliasMap = $modx->getOption('cache_alias_map', true);
         $modx->setOption('cache_alias_map', false);
-        
+
         $url       = urlencode($modx->makeUrl($resource->id, $resource->context_key, '', 'full'));
         $urlExists = $modx->getObject('seoUrl', array(
             'url'         => $url,
@@ -227,7 +227,7 @@ switch ($modx->event->name) {
                 'context_key' => $resource->context_key
             ));
         }
-        
+
         $modx->setOption('cache_alias_map', $cacheAliasMap);
         break;
 
@@ -262,10 +262,10 @@ switch ($modx->event->name) {
 
         $query->where(array(
             array(
-                'url' => urlencode('http://' . $url)
+                'url' => urlencode(rawurldecode('http://' . $url))
             ),
             array(
-                'url' => urlencode('https://' . $url)
+                'url' => urlencode(rawurldecode('https://' . $url))
             )
         ),xPDOQuery::SQL_OR);
 
@@ -353,7 +353,7 @@ switch ($modx->event->name) {
                 $stercseo->setWorkingContext($resource->get('context_key'));
 
                 $site_url = $stercseo->getOption('site_url', '', $modx->getOption('site_url'));
-                
+
                 $childResources = $modx->getIterator('modResource', $cond);
                 foreach ($childResources as $childResource) {
                     $url = urlencode($site_url . $childResource->get('uri'));


### PR DESCRIPTION
Fixes the issue with special characters in the URL by encoding the $_SERVER['REQUEST_URI'] before it is decoded. The issue that was stopping it from working was that special characters from $_SERVER['REQUEST_URI'] would already be encoded and then get re encoded again causing them not to match the URLs in the database