### PR TITLE
Fix issue #172

### DIFF
--- a/assets/components/stercseo/js/mgr/sections/resource.js
+++ b/assets/components/stercseo/js/mgr/sections/resource.js
@@ -199,8 +199,6 @@ Ext.onReady(function() {
                     ,labelSeparator: ''
                     ,items: [{
                         xtype: 'stercseo-grid-items'
-                        ,bodyStyle: 'margin-bottom: 10px;'
-                        ,bbar: false
                         ,store: StercSEO.record.test
                     },{
                         xtype: 'label'


### PR DESCRIPTION
This fix enables the bottom bar of the redirects grid in the resource view. That makes the pagination available too.